### PR TITLE
feat: Add formatDate function to template functions

### DIFF
--- a/internal/pkg/template/funcs.go
+++ b/internal/pkg/template/funcs.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"resumme-builder/internal/models"
 	"strings"
+	"time"
 )
 
 func isLast(index, length int) bool {
@@ -61,4 +62,13 @@ func evaluate(htmlStr string) template.HTML {
 
 func lowerEq(s1 string, s2 string) bool {
 	return strings.EqualFold(strings.ToLower(s1), strings.ToLower(s2))
+}
+
+func formatDate(s1 string, s2 string) string {
+	t, err := time.Parse("2006-01-02", s2)
+	if err != nil {
+		panic(err)
+	}
+
+	return t.Format(s1)
 }

--- a/internal/pkg/template/manager.go
+++ b/internal/pkg/template/manager.go
@@ -1,10 +1,11 @@
 package template
 
 import (
-	"github.com/pkg/errors"
 	"html/template"
 	"path"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 type Manager struct {
@@ -31,6 +32,7 @@ func (tm *Manager) GetTemplate(name string) (*template.Template, error) {
 		"getLastName":     getLastName,
 		"evaluate":        evaluate,
 		"lowerEq":         lowerEq,
+		"formatDate":      formatDate,
 	}
 
 	t := template.New(path.Base(templateFiles[0])).Funcs(templateFuncs)


### PR DESCRIPTION
This adds a new function to templates named formatDate that can be used the following way : {{ formatDate "Jan, 2006" "2024-07-03"  }}. time.Parse() and time.Time.Format() are used to do this hence the peculiar way date format is specified (cf. https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#Time.Format).

Note : It makes it necessary to specify dates in YYYY-MM-DD format. If this is an issue, the expected incoming format could be specified as an additional parameter by the template.