### PR TITLE
fix: wait for network idle event (#17)

### DIFF
--- a/internal/pkg/pdf/generator.go
+++ b/internal/pkg/pdf/generator.go
@@ -3,18 +3,20 @@ package pdf
 import (
 	"context"
 	"fmt"
+	"os"
+	"resumme-builder/internal/utils/logger"
+	"time"
+
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 	"github.com/pkg/errors"
-	"os"
-	"resumme-builder/internal/utils/logger"
-	"time"
 )
 
 const (
-	userAgentOverride = "WebScraper 1.0"
-	htmlSelector      = "body"
+	userAgentOverride   = "WebScraper 1.0"
+	htmlSelector        = "body"
+	networkReadyTimeOut = 15 * time.Second
 )
 
 // Generator provides functionality to generate PDF from HTML.
@@ -50,6 +52,12 @@ func (g *Generator) saveURLAsPDF(url string, pdf *[]byte) chromedp.Tasks {
 		chromedp.Navigate(url),
 		chromedp.WaitVisible(htmlSelector, chromedp.ByQuery),
 		chromedp.ActionFunc(func(ctx context.Context) error {
+			if err := waitForNetworkIdle(ctx, networkReadyTimeOut); err != nil {
+				logger.Log.Warn(err)
+			}
+			return nil
+		}),
+		chromedp.ActionFunc(func(ctx context.Context) error {
 			data, _, err := page.
 				PrintToPDF().
 				WithMarginLeft(0).
@@ -76,4 +84,24 @@ func getFilePathAsURL(filename string) string {
 	}
 
 	return fmt.Sprintf("file://%s/%s", path, filename)
+}
+
+func waitForNetworkIdle(ctx context.Context, timeout time.Duration) error {
+	idleChan := make(chan struct{})
+
+	chromedp.ListenTarget(ctx, func(ev interface{}) {
+		if event, ok := ev.(*page.EventLifecycleEvent); ok {
+			if event.Name == "networkIdle" {
+				close(idleChan)
+			}
+		}
+	})
+
+	select {
+	case <-idleChan:
+		// Network is idle
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout %.0f seconds waiting for network idle", timeout.Seconds())
+	}
 }


### PR DESCRIPTION
- Added `waitForNetworkIdle` helper function to wait for network idle event before generating PDF.
- Updated `saveURLAsPDF` to use `waitForNetworkIdle` to ensure all resources are fully loaded.